### PR TITLE
fix meta-spec 2, add dynamic_config, remove generated MANIFEST entries

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -4,8 +4,6 @@ Changes
 lib/Net/Ping.pm
 Makefile.PL
 MANIFEST			This list of files
-META.json
-META.yml			Module meta-data (added by MakeMaker)
 README
 t/000_load.t
 t/001_new.t

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -27,12 +27,17 @@ push @extras, LICENSE => 'perl_5'
 push @extras,
   META_MERGE => {
       'meta-spec' => { version => 2 },
+        dynamic_config => 0,
         resources   => {
             # TODO: 26 old issues still open at RT
             # https://rt.cpan.org/Public/Dist/Display.html?Name=Net-Ping
-            bugtracker  => 'https://github.com/rurban/Net-Ping/issues',
-            repository  => 'https://github.com/rurban/Net-Ping',
-            license     => 'http://dev.perl.org/licenses/',
+            bugtracker  => { web => 'https://github.com/rurban/Net-Ping/issues' },
+            repository  => {
+                url => 'https://github.com/rurban/Net-Ping.git',
+                web => 'https://github.com/rurban/Net-Ping',
+                type => 'git',
+            },
+            license    => [ 'http://dev.perl.org/licenses/' ],
         },
         release_status => 'stable',
   }


### PR DESCRIPTION
META.json/META.yml are added by make dist and EUMM complains if they're there since they arent in the repo.

Updated META_MERGE contents to meta-spec 2 so they get added to META properly.

and added dynamic_config 0 since Makefile.PL does not do dynamic prereqs.