### PR TITLE
Add IPv4 TimeStamp icmp support

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -2,6 +2,7 @@
 .travis.yml
 Changes
 lib/Net/Ping.pm
+lib/Net/Ping/TimeStamp.pm
 Makefile.PL
 MANIFEST			This list of files
 META.json
@@ -12,6 +13,7 @@ t/001_new.t
 t/010_pingecho.t
 t/020_external.t
 t/110_icmp_inst.t
+t/111_timestamp_icmp_inst.t
 t/120_udp_inst.t
 t/130_tcp_inst.t
 t/140_stream_inst.t
@@ -26,6 +28,7 @@ t/420_ping_syn_port.t
 t/450_service.t
 t/500_ping_icmp.t
 t/501_ping_icmpv6.t
+t/502_ping_timestamp_icmp.t
 t/510_ping_udp.t
 t/520_icmp_ttl.t
 t/600_pod.t

--- a/lib/Net/Ping/TimeStamp.pm
+++ b/lib/Net/Ping/TimeStamp.pm
@@ -124,3 +124,74 @@ sub ping_icmp
 }
 
 1;
+__END__
+
+=head1 NAME
+
+Net::Ping::TimeStamp - check a remote host for reachability
+
+=head1 SYNOPSIS
+
+    use Net::Ping::TimeStamp;
+
+    $p = Net::Ping::TimeStamp->new("icmp");
+    $p->bind($my_addr); # Specify source interface of pings
+    foreach $host (@host_array)
+    {
+        print "$host is ";
+        print "NOT " unless $p->ping($host, 2);
+        print "reachable.\n";
+        sleep(1);
+    }
+    $p->close();
+
+=head1 DESCRIPTION
+
+This module provides a Net::Ping derivated class which makes TimeStamp
+ICMP pings for icmp protocol ping.
+
+For not "icmp" type, this class does exactly what Net::Ping class would do.
+
+If the "icmp" protocol is specified, the ping() method sends an icmp
+timestamp message to the remote host, which is what the UNIX nmap program
+can do while -PP option is used.  If the echoed message is received from
+the remote host and the echoed information is correct, the remote host is
+considered reachable.  Specifying the "icmp" protocol requires that the
+program be run as root or that the program be setuid to root.
+
+=head2 Functions
+
+=over 4
+
+=item $p->ping_icmp([$host, $timeout, $family])
+X<ping_icmp>
+
+The X<ping> method used with the icmp protocol using timestamp message type.
+
+=back
+
+=head1 BUGS
+
+For a list of known issues, visit:
+
+L<https://rt.cpan.org/NoAuth/Bugs.html?Dist=Net-Ping>
+and
+L<https://github.com/rurban/Net-Ping/issues>
+
+To report a new bug, visit:
+
+L<https://github.com/rurban/Net-Ping/issues>
+
+=head1 AUTHORS
+
+  Original Net::Ping::TimeStamp author:
+    gbougard  at teclib.com (Guillaume Bougard)
+
+=head1 COPYRIGHT
+
+Copyright (c) 2018, Guillaume Bougard.  All rights reserved.
+
+This program is free software; you may redistribute it and/or
+modify it under the same terms as Perl itself.
+
+=cut

--- a/lib/Net/Ping/TimeStamp.pm
+++ b/lib/Net/Ping/TimeStamp.pm
@@ -1,0 +1,126 @@
+package Net::Ping::TimeStamp;
+
+use strict;
+use warnings;
+
+use parent qw(Net::Ping);
+
+use constant ICMP_TIMESTAMP         => 13;
+use constant ICMP_TIMESTAMP_REPLY   => 14;
+use constant ICMP_STRUCT            => "C2 n3 N3"; # Structure of a minimal timestamp ICMP packet
+
+# Just overide ping_icmp method to implement TimeStamp ICMP query and
+# TimeStamp ICMP reply support as specified in RFC 792
+# The method is a simplified version of the original Echo ICMP support from Net::Ping
+# It only supports IPv4 at this time
+sub ping_icmp
+{
+    my ($self,
+      $ip,                # Hash of addr (string), addr_in (packed), family
+      $timeout            # Seconds after which ping times out
+      ) = @_;
+
+    my ($saddr,             # sockaddr_in with port and ip
+        $checksum,          # Checksum of ICMP packet
+        $msg,               # ICMP packet to send
+        $len_msg,           # Length of $msg
+        $rbits,             # Read bits, filehandles for reading
+        $nfound,            # Number of ready filehandles found
+        $finish_time,       # Time ping should be finished
+        $done,              # set to 1 when we are done
+        $ret,               # Return value
+        $recv_msg,          # Received message including IP header
+        $from_saddr,        # sockaddr_in of sender
+        $from_port,         # Port packet was sent from
+        $from_ip,           # Packed IP of sender
+        $from_type,         # ICMP type
+        $from_subcode,      # ICMP subcode
+        $from_pid,          # ICMP packet id
+        $from_seq,          # ICMP packet sequence
+    );
+
+    $ip = $self->{host} if !defined $ip and $self->{host};
+    $timeout = $self->{timeout} if !defined $timeout and $self->{timeout};
+
+    socket($self->{fh}, $ip->{family}, Net::Ping::SOCK_RAW, $self->{proto_num}) ||
+        croak("icmp socket error - $!");
+
+    if (defined $self->{local_addr} &&
+        !CORE::bind($self->{fh}, _pack_sockaddr_in(0, $self->{local_addr}))) {
+        croak("icmp bind error - $!");
+    }
+    $self->_setopts();
+
+    $self->{seq} = ($self->{seq} + 1) % 65536; # Increment sequence
+    $checksum = 0;                          # No checksum for starters
+    $msg = pack(
+        ICMP_STRUCT, ICMP_TIMESTAMP, Net::Ping::SUBCODE,
+        $checksum, $self->{pid}, $self->{seq}, 0, 0, 0
+        );
+
+    $checksum = Net::Ping->checksum($msg);
+    $msg = pack(
+        ICMP_STRUCT, ICMP_TIMESTAMP, Net::Ping::SUBCODE,
+        $checksum, $self->{pid}, $self->{seq}, 0, 0, 0
+    );
+
+    $len_msg = length($msg);
+    $saddr = Net::Ping::_pack_sockaddr_in(Net::Ping::ICMP_PORT, $ip);
+    $self->{from_ip} = undef;
+    $self->{from_type} = undef;
+    $self->{from_subcode} = undef;
+    send($self->{fh}, $msg, Net::Ping::ICMP_FLAGS, $saddr); # Send the message
+
+    $rbits = "";
+    vec($rbits, $self->{fh}->fileno(), 1) = 1;
+    $ret = 0;
+    $done = 0;
+    $finish_time = &Net::Ping::time() + $timeout;      # Must be done by this time
+    while (!$done && $timeout > 0)          # Keep trying if we have time
+    {
+        $nfound = Net::Ping::mselect((my $rout=$rbits), undef, undef, $timeout); # Wait for packet
+        $timeout = $finish_time - &Net::Ping::time();    # Get remaining time
+        if (!defined($nfound))                # Hmm, a strange error
+        {
+            $ret = undef;
+            $done = 1;
+        }
+        elsif ($nfound)                     # Got a packet from somewhere
+        {
+            $recv_msg = "";
+            $from_pid = -1;
+            $from_seq = -1;
+            $from_saddr = recv($self->{fh}, $recv_msg, 1500, Net::Ping::ICMP_FLAGS);
+            ($from_port, $from_ip) = Net::Ping::_unpack_sockaddr_in($from_saddr, $ip->{family});
+            ($from_type, $from_subcode) = unpack("C2", substr($recv_msg, 20, 2));
+            if ($from_type == ICMP_TIMESTAMP_REPLY) {
+                ($from_pid, $from_seq) = unpack("n3", substr($recv_msg, 24, 4))
+                    if length $recv_msg >= 28;
+            } else {
+                ($from_pid, $from_seq) = unpack("n3", substr($recv_msg, 52, 4))
+                    if length $recv_msg >= 56;
+            }
+            $self->{from_ip} = $from_ip;
+            $self->{from_type} = $from_type;
+            $self->{from_subcode} = $from_subcode;
+            next if ($from_pid != $self->{pid});
+            next if ($from_seq != $self->{seq});
+            if ($self->ntop($from_ip) eq $self->ntop($ip)) { # Does the packet check out?
+                if ($from_type == ICMP_TIMESTAMP_REPLY) {
+                    $ret = 1;
+                    $done = 1;
+                } elsif ($from_type == Net::Ping::ICMP_UNREACHABLE) {
+                    $done = 1;
+                } elsif ($from_type == Net::Ping::ICMP_TIME_EXCEEDED()) {
+                    $ret = 0;
+                    $done = 1;
+                }
+            }
+        } else {     # Oops, timed out
+            $done = 1;
+        }
+    }
+    return $ret;
+}
+
+1;

--- a/t/111_timestamp_icmp_inst.t
+++ b/t/111_timestamp_icmp_inst.t
@@ -1,0 +1,26 @@
+# Test to make sure object can be instantiated for icmp protocol.
+# Root access is required to actually perform icmp testing.
+
+use strict;
+use Config;
+
+BEGIN {
+    unless (eval "require Socket") {
+        print "1..0 \# Skip: no Socket\n";
+        exit;
+    }
+    unless ($Config{d_getpbyname}) {
+        print "1..0 \# Skip: no getprotobyname\n";
+        exit;
+    }
+}
+
+use Test::More tests => 2;
+BEGIN {use_ok('Net::Ping::TimeStamp')};
+
+SKIP: {
+    skip "icmp timestamp ping requires root privileges.", 1
+        unless &Net::Ping::_isroot;
+    my $p = new Net::Ping::TimeStamp "icmp";
+    isa_ok($p, 'Net::Ping::TimeStamp', 'object can be instantiated for timestamp type icmp protocol');
+}

--- a/t/502_ping_timestamp_icmp.t
+++ b/t/502_ping_timestamp_icmp.t
@@ -1,0 +1,69 @@
+# Test to perform icmp protocol testing.
+# Root access is required.
+# In the core test suite it calls itself via sudo -n (no password) to test it.
+
+use strict;
+use Config;
+
+use Test::More;
+use Net::Ping;
+use Net::Ping::TimeStamp;
+
+BEGIN {
+    unless (eval "require Socket;") {
+        plan skip_all => 'no Socket';
+    }
+    unless ($Config{d_getpbyname}) {
+        plan skip_all => 'no getprotobyname';
+    }
+}
+
+my $is_devel = $ENV{PERL_CORE} || -d ".git" ? 1 : 0;
+# Note this rawsocket test code is considered anti-social in p5p and was removed in
+# their variant.
+# See http://nntp.perl.org/group/perl.perl5.porters/240707
+# Problem is that ping_icmp needs root perms, and previous bugs were
+# never caught. So I rather execute it via sudo in the core test suite
+# and on devel CPAN dirs, than not at all and risk further bitrot of this API.
+if (!Net::Ping::_isroot()) {
+    my $file = __FILE__;
+    my $lib = $ENV{PERL_CORE} ? '-I../../lib' : '-Mblib';
+    if ($is_devel && $Config{ccflags} =~ /fsanitize=address/ && $^O eq 'linux') {
+        plan skip_all => 'asan leak detector';
+    }
+    # -n prevents from asking for a password. rather fail then
+    # A technical problem is with leak-detectors, like asan, which
+    # require PERL_DESTRUCT_LEVEL=2 to be set in the root env.
+    my $env = "PERL_DESTRUCT_LEVEL=2";
+    if ($ENV{TEST_PING_HOST}) {
+        $env .= " TEST_PING_HOST=$ENV{TEST_PING_HOST}";
+    }
+    if ($is_devel && system("sudo -n $env \"$^X\" $lib $file") == 0)
+    {
+        exit;
+    } else {
+         plan skip_all => 'no sudo/failed';
+    }
+}
+
+SKIP: {
+    skip "icmp ping requires root privileges.", 1
+        if !Net::Ping::_isroot() or $^O eq 'MSWin32';
+    my $p = new Net::Ping::TimeStamp "icmp";
+    my $result = $p->ping("127.0.0.1");
+    if ($result == 1) {
+        is($result, 1, "icmp ping 127.0.0.1");
+    } else {
+        TODO: {
+            local $TODO = "localhost icmp firewalled?";
+            if (exists $ENV{TEST_PING_HOST}) {
+                my $result = $p->ping($ENV{TEST_PING_HOST});
+                is($result, 1, "icmp ping $ENV{TEST_PING_HOST}");
+            } else {
+                is($result, 1, "icmp ping 127.0.0.1");
+            }
+        }
+    }
+}
+
+done_testing;


### PR DESCRIPTION
We uses this icmp type for our FusionInventory agent network discovery task as it appears some admins filter echo icmp but forgot to filter timestamp type of ping. This gives us more chance to discover new devices.
Previously we used nmap to make this kind of network discovery, but licensing problems seems to not authorized us to analyse nmap output. We decided to [get rid of nmap usage](https://github.com/fusioninventory/fusioninventory-agent/pull/512) in our inventory solution. Then it would be better to get this type of support upstream into Net::Ping. If you think it should be in a separate package, I'll push it separately on CPAN as Net::Ping::TimeStamp only.
Here I only focus on IPv4 support, and I didn't investigate IPv6 support.

