### PR TITLE
Add IPv4 TimeStamp icmp support alternative

### DIFF
--- a/lib/Net/Ping.pm
+++ b/lib/Net/Ping.pm
@@ -645,11 +645,32 @@ use constant ICMP_ECHO        => 8;
 use constant ICMPv6_ECHO      => 128;
 use constant ICMP_TIME_EXCEEDED => 11; # ICMP packet types
 use constant ICMP_PARAMETER_PROBLEM => 12; # ICMP packet types
+use constant ICMP_TIMESTAMP   => 13;
+use constant ICMP_TIMESTAMP_REPLY => 14;
 use constant ICMP_STRUCT      => "C2 n3 A"; # Structure of a minimal ICMP packet
+use constant ICMP_TIMESTAMP_STRUCT => "C2 n3 N3"; # Structure of a minimal timestamp ICMP packet
 use constant SUBCODE          => 0; # No ICMP subcode for ECHO and ECHOREPLY
 use constant ICMP_FLAGS       => 0; # No special flags for send or recv
 use constant ICMP_PORT        => 0; # No port with ICMP
 use constant IP_MTU_DISCOVER  => 10; # linux only
+
+sub message_type
+{
+  my ($self,
+      $type
+      ) = @_;
+
+  croak "Setting message type only supported on 'icmp' protocol"
+    unless $self->{proto} eq 'icmp';
+
+  return $self->{message_type} || 'echo'
+    unless defined($type);
+
+  croak "Supported icmp message type are limited to 'echo' and 'timestamp': '$type' not supported"
+    unless $type =~ /^echo|timestamp$/i;
+
+  $self->{type} = lc($type);
+}
 
 sub ping_icmp
 {
@@ -671,6 +692,7 @@ sub ping_icmp
       $from_saddr,        # sockaddr_in of sender
       $from_port,         # Port packet was sent from
       $from_ip,           # Packed IP of sender
+      $timestamp_msg,     # ICMP timestamp message type
       $from_type,         # ICMP type
       $from_subcode,      # ICMP subcode
       $from_chk,          # ICMP packet checksum
@@ -681,6 +703,7 @@ sub ping_icmp
 
   $ip = $self->{host} if !defined $ip and $self->{host};
   $timeout = $self->{timeout} if !defined $timeout and $self->{timeout};
+  $timestamp_msg = $self->{type} && $self->{type} eq 'timestamp' ? 1 : 0;
 
   socket($self->{fh}, $ip->{family}, SOCK_RAW, $self->{proto_num}) ||
     croak("icmp socket error - $!");
@@ -694,8 +717,13 @@ sub ping_icmp
   $self->{seq} = ($self->{seq} + 1) % 65536; # Increment sequence
   $checksum = 0;                          # No checksum for starters
   if ($ip->{family} == AF_INET) {
-    $msg = pack(ICMP_STRUCT . $self->{data_size}, ICMP_ECHO, SUBCODE,
-                $checksum, $self->{pid}, $self->{seq}, $self->{data});
+    if ($timestamp_msg) {
+      $msg = pack(ICMP_TIMESTAMP_STRUCT, ICMP_TIMESTAMP, SUBCODE,
+                  $checksum, $self->{pid}, $self->{seq}, 0, 0, 0);
+    } else {
+      $msg = pack(ICMP_STRUCT . $self->{data_size}, ICMP_ECHO, SUBCODE,
+                  $checksum, $self->{pid}, $self->{seq}, $self->{data});
+    }
   } else {
                                           # how to get SRC
     my $pseudo_header = pack('a16a16Nnn', $ip->{addr_in}, $ip->{addr_in}, 8+length($self->{data}), 0, 0x003a);
@@ -705,8 +733,13 @@ sub ping_icmp
   }
   $checksum = Net::Ping->checksum($msg);
   if ($ip->{family} == AF_INET) {
-    $msg = pack(ICMP_STRUCT . $self->{data_size}, ICMP_ECHO, SUBCODE,
-                $checksum, $self->{pid}, $self->{seq}, $self->{data});
+    if ($timestamp_msg) {
+      $msg = pack(ICMP_TIMESTAMP_STRUCT, ICMP_TIMESTAMP, SUBCODE,
+                  $checksum, $self->{pid}, $self->{seq}, 0, 0, 0);
+    } else {
+      $msg = pack(ICMP_STRUCT . $self->{data_size}, ICMP_ECHO, SUBCODE,
+                  $checksum, $self->{pid}, $self->{seq}, $self->{data});
+    }
   } else {
     $msg = pack(ICMP_STRUCT . $self->{data_size}, ICMPv6_ECHO, SUBCODE,
                 $checksum, $self->{pid}, $self->{seq}, $self->{data});
@@ -740,7 +773,10 @@ sub ping_icmp
       $from_saddr = recv($self->{fh}, $recv_msg, 1500, ICMP_FLAGS);
       ($from_port, $from_ip) = _unpack_sockaddr_in($from_saddr, $ip->{family});
       ($from_type, $from_subcode) = unpack("C2", substr($recv_msg, 20, 2));
-      if ($from_type == ICMP_ECHOREPLY) {
+      if ($from_type == ICMP_TIMESTAMP_REPLY) {
+        ($from_pid, $from_seq) = unpack("n3", substr($recv_msg, 24, 4))
+          if length $recv_msg >= 28;
+      } elsif ($from_type == ICMP_ECHOREPLY) {
         #warn "ICMP_ECHOREPLY: ", $ip->{family}, " ",$recv_msg, ":", length($recv_msg);
         ($from_pid, $from_seq) = unpack("n2", substr($recv_msg, 24, 4))
           if ($ip->{family} == AF_INET && length $recv_msg == 28);
@@ -768,7 +804,10 @@ sub ping_icmp
       next if ($from_pid != $self->{pid});
       next if ($from_seq != $self->{seq});
       if (! $source_verify || ($self->ntop($from_ip) eq $self->ntop($ip))) { # Does the packet check out?
-        if (($from_type == ICMP_ECHOREPLY) || ($from_type == ICMPv6_ECHOREPLY)) {
+        if (!$timestamp_msg && (($from_type == ICMP_ECHOREPLY) || ($from_type == ICMPv6_ECHOREPLY))) {
+          $ret = 1;
+          $done = 1;
+        } elsif ($timestamp_msg && $from_type == ICMP_TIMESTAMP_REPLY) {
           $ret = 1;
           $done = 1;
         } elsif (($from_type == ICMP_UNREACHABLE) || ($from_type == ICMPv6_UNREACHABLE)) {

--- a/lib/Net/Ping.pm
+++ b/lib/Net/Ping.pm
@@ -669,7 +669,7 @@ sub message_type
   croak "Supported icmp message type are limited to 'echo' and 'timestamp': '$type' not supported"
     unless $type =~ /^echo|timestamp$/i;
 
-  $self->{type} = lc($type);
+  $self->{message_type} = lc($type);
 }
 
 sub ping_icmp
@@ -703,7 +703,7 @@ sub ping_icmp
 
   $ip = $self->{host} if !defined $ip and $self->{host};
   $timeout = $self->{timeout} if !defined $timeout and $self->{timeout};
-  $timestamp_msg = $self->{type} && $self->{type} eq 'timestamp' ? 1 : 0;
+  $timestamp_msg = $self->{message_type} && $self->{message_type} eq 'timestamp' ? 1 : 0;
 
   socket($self->{fh}, $ip->{family}, SOCK_RAW, $self->{proto_num}) ||
     croak("icmp socket error - $!");
@@ -2285,6 +2285,15 @@ object.
 
 The bind() call can be omitted when specifying the C<bind> option to
 new().
+
+=item $p->message_type([$ping_type]);
+X<message_type>
+
+When you are using the "icmp" protocol, this call permit to change the
+message type to 'echo' or 'timestamp' (only for IPv4, see RFC 792).
+
+Without argument, it returns the currently used icmp protocol message type.
+By default, it returns 'echo'.
 
 =item $p->open($host);
 X<open>

--- a/t/200_ping_tcp.t
+++ b/t/200_ping_tcp.t
@@ -28,12 +28,18 @@ BEGIN {
 #
 # $ PERL_CORE=1 make test
 
-use Test::More tests => 12;
+use Test::More tests => 13;
 BEGIN {use_ok('Net::Ping');}
 
 my $p = new Net::Ping "tcp",9;
 
 isa_ok($p, 'Net::Ping', 'new() worked');
+
+# message_type can't be used
+eval {
+  $p->message_type();
+};
+like($@, qr/message type only supported on 'icmp' protocol/, "message_type() API only concern 'icmp' protocol");
 
 isnt($p->ping("localhost"), 0, 'Test on the default port');
 

--- a/t/300_ping_stream.t
+++ b/t/300_ping_stream.t
@@ -30,13 +30,19 @@ BEGIN {
 #   to really test the stream protocol ping.  See
 #   the end of this document on how to enable it.
 
-use Test::More tests => 22;
+use Test::More tests => 23;
 use Net::Ping;
 
 my $p = new Net::Ping "stream";
 
 # new() worked?
 isa_ok($p, 'Net::Ping', 'new() worked');
+
+# message_type can't be used
+eval {
+  $p->message_type();
+};
+like($@, qr/message type only supported on 'icmp' protocol/, "message_type() API only concern 'icmp' protocol");
 
 is($p->ping("localhost"), 1, 'Attempt to connect to the echo port');
 

--- a/t/400_ping_syn.t
+++ b/t/400_ping_syn.t
@@ -45,7 +45,7 @@ my %webs = (
 );
 
 use Test::More;
-plan tests => 3 + 2 * keys %webs;
+plan tests => 4 + 2 * keys %webs;
 
 use_ok('Net::Ping');
 
@@ -68,6 +68,12 @@ isa_ok($p, 'Net::Ping', 'new() worked');
 # Change to use the more common web port.
 # (Make sure getservbyname works in scalar context.)
 cmp_ok(($p->{port_num} = getservbyname("http", "tcp")), '>', 0, 'valid port');
+
+# message_type can't be used
+eval {
+  $p->message_type();
+};
+like($@, qr/message type only supported on 'icmp' protocol/, "message_type() API only concern 'icmp' protocol");
 
 # check if network is up
 eval { $p->ping('www.google.com.'); };

--- a/t/500_ping_icmp.t
+++ b/t/500_ping_icmp.t
@@ -50,6 +50,11 @@ SKIP: {
     if !Net::Ping::_isroot() or $^O eq 'MSWin32';
   my $p = new Net::Ping "icmp";
   is($p->message_type(), 'echo', "default icmp message type is 'echo'");
+  # message_type fails on wrong message type
+  eval {
+    $p->message_type('information');
+  };
+  like($@, qr/icmp message type are limited to 'echo' and 'timestamp'/, "Failure on wrong message type");
   my $result = $p->ping("127.0.0.1");
   if ($result == 1) {
     is($result, 1, "icmp ping 127.0.0.1");

--- a/t/500_ping_icmp.t
+++ b/t/500_ping_icmp.t
@@ -46,9 +46,10 @@ if (!Net::Ping::_isroot()) {
 }
 
 SKIP: {
-  skip "icmp ping requires root privileges.", 1
+  skip "icmp ping requires root privileges.", 2
     if !Net::Ping::_isroot() or $^O eq 'MSWin32';
   my $p = new Net::Ping "icmp";
+  is($p->message_type(), 'echo', "default icmp message type is 'echo'");
   my $result = $p->ping("127.0.0.1");
   if ($result == 1) {
     is($result, 1, "icmp ping 127.0.0.1");

--- a/t/501_ping_icmpv6.t
+++ b/t/501_ping_icmpv6.t
@@ -40,6 +40,11 @@ SKIP: {
   skip "icmpv6 ping requires root privileges.", 1
     if !Net::Ping::_isroot() or $^O eq 'MSWin32';
   my $p = new Net::Ping "icmpv6";
+  # message_type can't be used
+  eval {
+    $p->message_type();
+  };
+  like($@, qr/message type only supported on 'icmp' protocol/, "message_type() API only concern 'icmp' protocol");
   my $rightip = "2001:4860:4860::8888"; # pingable ip of google's dnsserver
   # for a firewalled ipv6 network try an optional local ipv6 host
   $rightip = $ENV{TEST_PING6_HOST} if $ENV{TEST_PING6_HOST};

--- a/t/510_ping_udp.t
+++ b/t/510_ping_udp.t
@@ -14,7 +14,7 @@ sub isWindowsVista {
 
 }
 
-use Test::More tests => 2;
+use Test::More tests => 3;
 BEGIN {use_ok('Net::Ping')};
 
 SKIP: {
@@ -23,5 +23,10 @@ SKIP: {
     skip "No getprotobyname", 1 unless $Config{d_getpbyname};
     skip "Not allowed on $^O", 1 if $^O =~ /^(hpux|irix|aix)$/;
     my $p = new Net::Ping "udp";
+    # message_type can't be used
+    eval {
+        $p->message_type();
+    };
+    like($@, qr/message type only supported on 'icmp' protocol/, "message_type() API only concern 'icmp' protocol");
     is($p->ping("127.0.0.1"), 1);
 }


### PR DESCRIPTION
* Add message_type() API to get or set the IPv4 ICMP protocol message type
* Support 'timestamp' message type protocol

This is an alternative to PR #9 
Here I propose to authorize the use of `message_type()` API to get/set the message type. Default is leaved to echo ping, permitted values are 'echo' or 'timestamp'.

TODO:
* [x] Update POD
* [x] Update unittest