### PR TITLE
Un-TODO three tests with respect to FreeBSD

### DIFF
--- a/t/010_pingecho.t
+++ b/t/010_pingecho.t
@@ -14,7 +14,6 @@ BEGIN {use_ok('Net::Ping')};
 TODO: {
     local $TODO = "Not working on os390 smoker; may be a permissions problem"
       if $^O eq 'os390';
-    $TODO = "Not working on freebsd" if $^O eq 'freebsd';
     my $result = pingecho("127.0.0.1");
     is($result, 1, "pingecho 127.0.0.1 works");
 }

--- a/t/450_service.t
+++ b/t/450_service.t
@@ -78,7 +78,7 @@ is($p->ping("127.0.0.1"), 1, 'first port is reachable');
 $p->{port_num} = $port2;
 
 {
-    local $TODO = "Believed not to work on $^O" if $^O =~ /^(?:hpux|os390|freebsd)$/;
+    local $TODO = "Believed not to work on $^O" if $^O =~ /^(?:hpux|os390)$/;
     is($p->ping("127.0.0.1"), 1, 'second port is reachable');
 }
 
@@ -133,7 +133,7 @@ SKIP: {
 
   {
     local $TODO = "Believed not to work on $^O"
-      if $^O =~ /^(?:hpux|MSWin32|os390|freebsd)$/;
+      if $^O =~ /^(?:hpux|MSWin32|os390)$/;
     is($p->ack(), '127.0.0.1', 'IP should be reachable');
   }
 }


### PR DESCRIPTION
Once Net-Ping 2.72 was synched into perl 5 blead, 3 tests that were
previously believed to fail on FreeBSD began to pass, albeit with "TODO
passed" messages.  This patch removes the TODO status for those tests
when on FreeBSD.