### PR TITLE
Fix and improve the metadata structure

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -31,8 +31,12 @@ push @extras,
             # TODO: 26 old issues still open at RT
             # https://rt.cpan.org/Public/Dist/Display.html?Name=Net-Ping
             bugtracker  => 'https://github.com/rurban/Net-Ping/issues',
-            repository  => 'https://github.com/rurban/Net-Ping',
-            license     => 'http://dev.perl.org/licenses/',
+            repository  => {
+                type => 'git',
+                url => 'https://github.com/rurban/Net-Ping.git',
+                web => 'https://github.com/rurban/Net-Ping',
+            },
+            license     => [ 'http://dev.perl.org/licenses/' ],
         },
         #release_status => 'stable',
   }


### PR DESCRIPTION
The previous data structure prevented metadata appearing in `META.json` and `META.yml`.  Putting the value of _license_ in an arrayref fixes this.