### PR TITLE
Fix Socket::VERSION evaluation

### DIFF
--- a/lib/Net/Ping.pm
+++ b/lib/Net/Ping.pm
@@ -46,7 +46,7 @@ my $NIx_NOSERV = eval { Socket::NIx_NOSERV() } || 2;
 #my $IPV6_HOPLIMIT  = eval { Socket::IPV6_HOPLIMIT() };  # ping6 -h 0-255
 my $qr_family = qr/^(?:(?:(:?ip)?v?(?:4|6))|${\AF_INET}|$AF_INET6)$/;
 my $qr_family4 = qr/^(?:(?:(:?ip)?v?4)|${\AF_INET})$/;
-my $Socket_VERSION = eval { $Socket::VERSION };
+my $Socket_VERSION = eval $Socket::VERSION;
 
 if ($^O =~ /Win32/i) {
   # Hack to avoid this Win32 spewage:


### PR DESCRIPTION
The Net::Ping module evaluates the `$Socket::VERSION` variable and then assigns the result to `$Socket_VERSION`. This is done so if the version contains an underscore (e.g. '2.020_03') it gets properly converted to a number. `$Socket_VERSION` can be then compared without errors/warnings with numeric literal versions in the rest of the code. The conversion is however currently attempted using block eval which results in the same version string without converting it to a number. The patch fixes the problem by using string eval.